### PR TITLE
prepare publish.yml for in-branch work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: Build & publish module to registry
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ on:
 # or [0-9]+.[0-9]+.[0-9]+-rc optionally followed by digits
 
 jobs:
-  validate-tag:
+  publish:
+    name: Build and Upload module
     runs-on: ubuntu-latest
     steps:
       - name: Validate tag format
@@ -28,11 +29,7 @@ jobs:
             echo "Error: tag does not match semver"
             exit 1
           fi
-  publish:
-    needs: validate-tag
-    name: Build and Upload module
-    runs-on: ubuntu-latest
-    steps:
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
-        with:
-          path: ~/.conan2
-          key: ${{runner.os}}-conan-${{ hashFiles('**/conanfile.py') }}
-          restore-keys: |
-            ${{ runner.os }}-conan-
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: ~/.conan2
+      #     key: ${{runner.os}}-conan-${{ hashFiles('**/conanfile.py') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-conan-
 
       - name: Build and Publish
         uses: viamrobotics/build-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate tag format
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           TAG="${{ github.event.release.tag_name }}"
           echo "Validating tag: $TAG"
@@ -43,7 +44,8 @@ jobs:
       - name: Build and Publish
         uses: viamrobotics/build-action@v1
         with:
-          version: ${{ github.ref_name }}
+          # only publish a version if this is from a release
+          version: ${{ github.event_name == 'release' && github.ref_name || '' }}
           ref: ${{ github.sha }}
           key-id: ${{ secrets.viam_key_id }}
           key-value: ${{ secrets.viam_key_value }}


### PR DESCRIPTION
## What changed
- add workflow_dispatch trigger
- omit version tag and tag validation when running in workflow_dispatch
- merge the two jobs (waste of a runner to keep them separate)
- comment out conan cache action for now; the build isn't running locally
## Why
Primary goal here is to add the `on: workflow_dispatch` trigger; once this is present on the main branch, developers can trigger runs of this workflow from other branches.