### PR TITLE
[RSDK-10385] Build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+if (WIN32)
+  # Use a newer version of CMake on Windows, so we are NEW for
+  # https://cmake.org/cmake/help/latest/policy/CMP0149.html
+  cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+endif()
+
 set(CMAKE_PROJECT_VERSION 0.0.1)
 
 project(tflite_cpu

--- a/conanfile.py
+++ b/conanfile.py
@@ -44,7 +44,6 @@ class viamTfliteCpu(ConanFile):
         self.requires("viam-cpp-sdk/0.7.0")
         self.requires("tensorflow-lite/2.15.0")
         self.requires("abseil/20240116.2", override=True)
-        self.requires("xtensor/0.25.0")
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
We need a newer cmake min set on windows to default opt-in to the policy indicated in the link. This makes it easier to build with conan and target a specific desired windows version as the build target.

As a drive-by, xtensor is removed, since we obtain that dependency transitively from the C++ SDK.