### PR TITLE
[RSDK-10269] Get the tflite_cpu module building on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: setup-and-module
       run: |
-        echo "xxx acm contents" >> module.tar.gz
+        make setup
+        make module.tar.gz
     - name: upload-module
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: setup-and-module
       run: |
-        type nul > module.tar.gz
+        type NUL > module.tar.gz
     - name: upload-module
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: setup-and-module
       run: |
-        type NUL > module.tar.gz
+        echo "xxx acm contents" >> module.tar.gz
     - name: upload-module
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: setup
-      run: make setup
+      run: |
+        make setup
+        make module.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,11 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v4
-    - name: setup
+    - name: setup-and-module
       run: |
-        make setup
-        make module.tar.gz
+        type nul > module.tar.gz
+    - name: upload-module
+      uses: actions/upload-artifact@v4
+      with:
+        name: module
+        path: ./module.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ ifeq ($(OS),Windows_NT)
   BIN_EXT := .exe
   SCRIPT_EXT := .bat
   PATHSEP := \\
+  # Scripts for windows are written in powershell
+  # (e.g. setup.ps1). However, I was unable to find a way to invoke
+  # those scripts from here in make in a way where the exit status was
+  # returned in such a way that a failed script would terminate
+  # make. Instead, we invoke a little wrapper batch script with cmd
+  # syntax, which calls powershell for us and then explicitly sets the
+  # exit status.
   SUBSHELL := cmd /C
 else
   BIN_EXT :=
@@ -23,7 +30,7 @@ setup:
 	$(SUBSHELL) bin$(PATHSEP)setup$(SCRIPT_EXT)
 
 module.tar.gz: $(BIN) meta.json
-	$(SUBSHELL) bin$(PATHSEP)package$(SCRIPT_EXT) $(BIN) meta.json
+	$(SUBSHELL) bin$(PATHSEP)package$(SCRIPT_EXT) $^
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,29 @@
 ifeq ($(OS),Windows_NT)
   BIN_EXT := .exe
-  SCRIPT_EXT := .ps1
-  SUBSHELL := powershell -ExecutionPolicy Bypass -File
+  SCRIPT_EXT := .bat
+  PATHSEP := \\
+  SUBSHELL := cmd /C
 else
   BIN_EXT :=
   SCRIPT_EXT := .sh
+  PATHSEP := /
   SUBSHELL :=
 endif
+
 BIN := build-conan/build/Release/tflite_cpu$(BIN_EXT)
 
 .PHONY: tflite_cpu
 tflite_cpu: $(BIN)
 
-$(BIN): src/*
-	$(SUBSHELL) ./bin/build$(SCRIPT_EXT)
+$(BIN): conanfile.py src/*
+	$(SUBSHELL) bin$(PATHSEP)build$(SCRIPT_EXT)
 
 .PHONY: setup
 setup:
-	$(SUBSHELL) ./bin/setup$(SCRIPT_EXT)
+	$(SUBSHELL) bin$(PATHSEP)setup$(SCRIPT_EXT)
 
-module.tar.gz: tflite_cpu
-ifeq ($(OS),Windows_NT)
-	7z a -ttar module.tar $(BIN) meta.json
-	7z a -tgzip module.tar.gz module.tar
-else
-	tar -czvf module.tar.gz $(BIN)
-endif
+module.tar.gz: $(BIN) meta.json
+	$(SUBSHELL) bin$(PATHSEP)package$(SCRIPT_EXT) $(BIN) meta.json
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ setup:
 
 module.tar.gz: tflite_cpu
 ifeq ($(OS),Windows_NT)
-	7z a -tgzip module.tar.gz $(BIN)
+	7z a -ttar module.tar $(BIN) meta.json
+	7z a -tgzip module.tar.gz module.tar
 else
 	tar -czvf module.tar.gz $(BIN)
 endif

--- a/bin/build.bat
+++ b/bin/build.bat
@@ -1,0 +1,1 @@
+Powershell.exe -ExecutionPolicy Bypass -Command "& { bin\build.ps1; exit $LASTEXITCODE }"

--- a/bin/build.bat
+++ b/bin/build.bat
@@ -1,1 +1,2 @@
+:: Delegate to powershell rather than trying to script in batch
 Powershell.exe -ExecutionPolicy Bypass -Command "& { bin\build.ps1; exit $LASTEXITCODE }"

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -1,10 +1,20 @@
+# Fail fast
 $ErrorActionPreference = "Stop"
 
-Remove-Item -Recurse -Force build-conan -ErrorAction SilentlyContinue
-
+# Ensure that things installed with choco are visible to us
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 refreshenv
 
+# Clean up any prior build
+Remove-Item -Recurse -Force build-conan -ErrorAction SilentlyContinue
+
+# Build the tflite_cpu module
+#
+# We want a static binary, so we turn of shared. Elect for C++17
+# compilation, since it seems some of the dependencies we pick mandate
+# it anyway. Pin to the Windows 10 1809 associated windows SDK, and
+# opt for the static compiler runtime so we don't have a dependency on
+# the VC redistributable.
 conan build . `
       --output-folder=build-conan `
       --build=missing `

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -10,7 +10,7 @@ Remove-Item -Recurse -Force build-conan -ErrorAction SilentlyContinue
 
 # Build the tflite_cpu module
 #
-# We want a static binary, so we turn of shared. Elect for C++17
+# We want a static binary, so we turn off shared. Elect for C++17
 # compilation, since it seems some of the dependencies we pick mandate
 # it anyway. Pin to the Windows 10 1809 associated windows SDK, and
 # opt for the static compiler runtime so we don't have a dependency on

--- a/bin/build.ps1
+++ b/bin/build.ps1
@@ -2,6 +2,9 @@ $ErrorActionPreference = "Stop"
 
 Remove-Item -Recurse -Force build-conan -ErrorAction SilentlyContinue
 
+Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+refreshenv
+
 conan build . `
       --output-folder=build-conan `
       --build=missing `

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,8 +5,14 @@
 #     -o pipefail: if something in the middle of a pipeline fails, the whole thing fails
 set -euxo pipefail
 
+# Clean up any prior build
 rm -rf build-conan
 
+# Build the tflite_cpu module
+#
+# We want a static binary, so we turn off shared. Elect for C++17
+# compilation, since it seems some of the dependencies we pick mandate
+# it anyway.
 conan build . \
       --output-folder=build-conan \
       --build=missing \

--- a/bin/fixup_windows_entrypoint.jq
+++ b/bin/fixup_windows_entrypoint.jq
@@ -1,0 +1,1 @@
+.entrypoint += ".exe"

--- a/bin/package.bat
+++ b/bin/package.bat
@@ -1,1 +1,2 @@
+:: Delegate to powershell rather than trying to script in batch
 Powershell.exe -ExecutionPolicy Bypass -Command "& { bin\package.ps1 %*; exit $LASTEXITCODE }"

--- a/bin/package.bat
+++ b/bin/package.bat
@@ -1,0 +1,1 @@
+Powershell.exe -ExecutionPolicy Bypass -Command "& { bin\package.ps1 %*; exit $LASTEXITCODE }"

--- a/bin/package.ps1
+++ b/bin/package.ps1
@@ -6,7 +6,7 @@ refreshenv
 # Fixup `meta.json` to have `.exe at the end
 Copy-Item meta.json meta.json.backup
 
-jq -f .\bin\fixup_windows_entrypoint.jq meta.json.backup | Out-File -FilePath meta.json -Encoding utf8
+jq -f .\bin\fixup_windows_entrypoint.jq meta.json.backup | Out-File -FilePath meta.json -Encoding ASCII
 
 7z a -ttar module.tar $args
 7z a -tgzip -sdel module.tar.gz module.tar

--- a/bin/package.ps1
+++ b/bin/package.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop"
+
+Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+refreshenv
+
+# Fixup `meta.json` to have `.exe at the end
+Copy-Item meta.json meta.json.backup
+
+jq -f .\bin\fixup_windows_entrypoint.jq meta.json.backup | Out-File -FilePath meta.json -Encoding utf8
+
+7z a -ttar module.tar $args
+7z a -tgzip -sdel module.tar.gz module.tar
+
+Remove-Item meta.json
+Move-Item meta.json.backup meta.json

--- a/bin/package.ps1
+++ b/bin/package.ps1
@@ -1,15 +1,18 @@
+# Fail fast
 $ErrorActionPreference = "Stop"
 
+# Ensure that things installed with choco are visible to us
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 refreshenv
 
 # Fixup `meta.json` to have `.exe at the end
 Copy-Item meta.json meta.json.backup
-
 jq -f .\bin\fixup_windows_entrypoint.jq meta.json.backup | Out-File -FilePath meta.json -Encoding ASCII
 
+# Tar up all the command line arguments, then gzip them
 7z a -ttar module.tar $args
 7z a -tgzip -sdel module.tar.gz module.tar
 
+# Clean house
 Remove-Item meta.json
 Move-Item meta.json.backup meta.json

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,1 +1,9 @@
+#!/bin/bash
+# set -e: exit with errors if anything fails
+#     -u: it's an error to use an undefined variable
+#     -x: print out every command before it runs
+#     -o pipefail: if something in the middle of a pipeline fails, the whole thing fails
+set -euxo pipefail
+
+# Just tar up all the files we were given on the command line
 tar -czvf module.tar.gz "$@"

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,0 +1,1 @@
+tar -czvf module.tar.gz "$@"

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -1,1 +1,2 @@
+:: Delegate to powershell rather than trying to script in batch
 Powershell.exe -ExecutionPolicy Bypass -Command "& { bin\setup.ps1; exit $LASTEXITCODE }"

--- a/bin/setup.bat
+++ b/bin/setup.bat
@@ -1,0 +1,1 @@
+Powershell.exe -ExecutionPolicy Bypass -Command "& { bin\setup.ps1; exit $LASTEXITCODE }"

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -16,7 +16,7 @@ git clone https://github.com/acmorrow/viam-cpp-sdk.git
 Push-Location viam-cpp-sdk
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements
-git checkout windows
+git checkout releases/v0.9.0
 
 # Build the C++ SDK repo.
 #

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -12,7 +12,7 @@ if (!$?) { Write-Host "Conan is already installed" }
 # Clone the C++ SDK repo
 mkdir tmp_cpp_sdk
 Push-Location tmp_cpp_sdk
-git clone https://github.com/acmorrow/viam-cpp-sdk.git
+git clone https://github.com/viamrobotics/viam-cpp-sdk.git
 Push-Location viam-cpp-sdk
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -23,7 +23,7 @@ git checkout releases/v0.9.0
 
 # Build the C++ SDK repo.
 #
-# We are want a static binary, so we turn off shared. Elect for C++17
+# We want a static binary, so we turn off shared. Elect for C++17
 # compilation, since it seems some of the dependencies we pick mandate
 # it anyway. Pin to the Windows 10 1809 associated windows SDK, and
 # opt for the static compiler runtime so we don't have a dependency on

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 
-# Set up conan
-choco install -y conan cmake git 7zip
+# Set up conan and other friends we met along the way
+choco install -y conan cmake git 7zip jq
 
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 refreshenv

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -1,4 +1,4 @@
-# Fail fastp
+# Fail fast
 $ErrorActionPreference = "Stop"
 
 # Set up conan and other friends we met along the way
@@ -23,7 +23,7 @@ git checkout releases/v0.9.0
 
 # Build the C++ SDK repo.
 #
-# We are want a static binary, so we turn of shared. Elect for C++17
+# We are want a static binary, so we turn off shared. Elect for C++17
 # compilation, since it seems some of the dependencies we pick mandate
 # it anyway. Pin to the Windows 10 1809 associated windows SDK, and
 # opt for the static compiler runtime so we don't have a dependency on

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -1,11 +1,14 @@
+# Fail fastp
 $ErrorActionPreference = "Stop"
 
 # Set up conan and other friends we met along the way
 choco install -y conan cmake git 7zip jq
 
+# Ensure that things installed with choco are visible to us
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 refreshenv
 
+# Initialize conan if it hasn't been already
 conan profile detect
 if (!$?) { Write-Host "Conan is already installed" }
 
@@ -20,6 +23,12 @@ git checkout releases/v0.9.0
 
 # Build the C++ SDK repo.
 #
+# We are want a static binary, so we turn of shared. Elect for C++17
+# compilation, since it seems some of the dependencies we pick mandate
+# it anyway. Pin to the Windows 10 1809 associated windows SDK, and
+# opt for the static compiler runtime so we don't have a dependency on
+# the VC redistributable.
+#
 # TODO: Note `-tf ""`, which disables the self test. I have not been
 # able to get this working on windows.
 conan create . `
@@ -30,6 +39,7 @@ conan create . `
       -s:h compiler.runtime=static `
       -tf `"`"
 
+# Clean up
 Pop-Location  # viam-cpp-sdk
 Pop-Location  # tmp_cpp_sdk
 Remove-Item -Recurse -Force tmp_cpp_sdk

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -12,11 +12,11 @@ if (!$?) { Write-Host "Conan is already installed" }
 # Clone the C++ SDK repo
 mkdir tmp_cpp_sdk
 Push-Location tmp_cpp_sdk
-git clone https://github.com/viamrobotics/viam-cpp-sdk.git
+git clone https://github.com/acmorrow/viam-cpp-sdk.git
 Push-Location viam-cpp-sdk
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements
-git checkout releases/v0.8.0
+git checkout windows
 
 # Build the C++ SDK repo.
 #

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -16,7 +16,7 @@ git clone https://github.com/viamrobotics/viam-cpp-sdk.git
 pushd viam-cpp-sdk
 
 # NOTE: If you change this version, also change it in the `conanfile.py` requirements
-git checkout releases/v0.8.0
+git checkout releases/v0.9.0
 
 # Build the C++ SDK repo
 conan create . \

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -19,11 +19,16 @@ pushd viam-cpp-sdk
 git checkout releases/v0.9.0
 
 # Build the C++ SDK repo
+#
+# We want a static binary, so we turn off shared. Elect for C++17
+# compilation, since it seems some of the dependencies we pick mandate
+# it anyway.
 conan create . \
       --build=missing \
       -o "&:shared=False" \
       -s:h compiler.cppstd=17
 
+# Cleanup
 popd  # viam-cpp-sdk
 popd  # tmp_cpp_sdk
 rm -rf tmp_cpp_sdk

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,7 @@ class viamTfliteCpu(ConanFile):
     def requirements(self):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
         # should also be updated in `bin/setup.{sh,ps1}`.
-        self.requires("viam-cpp-sdk/0.8.0")
+        self.requires("viam-cpp-sdk/0.9.0")
         self.requires("tensorflow-lite/2.15.0")
         self.requires("abseil/20240116.2", override=True)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,7 @@ class viamTfliteCpu(ConanFile):
     def requirements(self):
         # NOTE: If you update the `viam-cpp-sdk` dependency here, it
         # should also be updated in `bin/setup.{sh,ps1}`.
-        self.requires("viam-cpp-sdk/0.9.0")
+        self.requires("viam-cpp-sdk/0.8.0")
         self.requires("tensorflow-lite/2.15.0")
         self.requires("abseil/20240116.2", override=True)
 

--- a/meta.json
+++ b/meta.json
@@ -3,7 +3,7 @@
     "build": {
         "setup": "make setup",
         "build": "make module.tar.gz",
-        "arch": ["linux/amd64", "linux/arm64", "darwin/arm64"],
+        "arch": ["linux/amd64", "linux/arm64", "darwin/arm64", "windows/amd64"],
         "darwin_deps": ["pkg-config"]
     },
     "visibility": "public",
@@ -15,5 +15,5 @@
         "model": "viam:mlmodel-tflite:tflite_cpu"
       }
     ],
-    "entrypoint": "build/Release/tflite_cpu"
+    "entrypoint": "build-conan/build/Release/tflite_cpu.exe"
 }

--- a/meta.json
+++ b/meta.json
@@ -15,5 +15,5 @@
         "model": "viam:mlmodel-tflite:tflite_cpu"
       }
     ],
-    "entrypoint": "build-conan/build/Release/tflite_cpu.exe"
+    "entrypoint": "build-conan/build/Release/tflite_cpu"
 }


### PR DESCRIPTION
I've not yet verified that I can actually build for macOS or Linux with these changes, but I have been able to do workflow runs (thanks @abe-winter) that validate that this all works for getting a `module.tar.gz` attached to the workflow run, which can then be manually uploaded to the registry.
