### PR TITLE
bugfix: get meta.json in the spot where we upload the module

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,9 @@ jobs:
         run: |
           sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
           sudo chmod a+rx /usr/local/bin/viam
+      # Although we don't need to check out any of the code, we do need to check out meta.json.
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Download the build artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.conan2
-          key: ${{ matrix.build_target.runs_on }}-conan-${{ hashFiles('**/conanfile.py') }}
+          key: ${{ matrix.runs_on }}-conan-${{ hashFiles('**/conanfile.py') }}
           restore-keys: |
-            ${{ matrix.build_target.runs_on }}-conan-
+            ${{ matrix.runs_on }}-conan-
 
       - name: Install dependencies
         run: make setup


### PR DESCRIPTION
Sigh. The two lines I couldn't test (invoking the Viam CLI) are failing because they can't find meta.json, because the code was built on a different runner than we're using to upload to the registry. Like #30, I don't have a way to try this out without merging, so still can't tell if it's right. but hopefully it'll work this time...