### PR TITLE
Don't modify meta.json in the Windows build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,19 +40,14 @@ jobs:
         build_target:
           - runs_on: ubuntu-22.04
             cache_dir: ~/.conan2
-            meta_json: meta.json
           - runs_on: ubuntu-22.04-arm
             cache_dir: ~/.conan2
-            meta_json: meta.json
           - runs_on: macos-14
             cache_dir: ~/.conan2
-            meta_json: meta.json
           - runs_on: macos-13
             cache_dir: ~/.conan2
-            meta_json: meta.json
           - runs_on: windows-2019
             cache_dir: C:\Users\runneradmin\.conan2
-            meta_json: meta.windows.json
     runs-on: ${{ matrix.build_target.runs_on }}
     steps:
       - name: Checkout
@@ -75,9 +70,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.build_target.runs_on }}-module-${{ github.sha }}
-          path: |
-            module.tar.gz
-            ${{ matrix.build_target.meta_json }}
+          path: module.tar.gz
 
   publish:
     name: Upload module
@@ -87,19 +80,14 @@ jobs:
         build_target:
           - platform: linux/amd64
             built_on: ubuntu-22.04
-            meta_json: meta.json
           - platform: linux/arm64
             built_on: ubuntu-22.04-arm
-            meta_json: meta.json
           - platform: darwin/arm64
             built_on: macos-14
-            meta_json: meta.json
           - platform: darwin/amd64
             built_on: macos-13
-            meta_json: meta.json
           - platform: windows/amd64
             built_on: windows-2019
-            meta_json: meta.windows.json
     runs-on: ubuntu-latest
     steps:
       - name: Install Viam CLI
@@ -107,7 +95,9 @@ jobs:
           sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
           sudo chmod a+rx /usr/local/bin/viam
       # Although we don't need to check out any of the code, we do need to check out meta.json.
-      - name: Download the build artifacts
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download the build artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.build_target.built_on }}-module-${{ github.sha }}
@@ -115,8 +105,4 @@ jobs:
       - name: Publish build to Viam registry
         run: |
           viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          # On Windows, we have meta.windows.json instead of meta.json. Rename it. Renaming a file
-          # to itself (e.g., on Linux, where it's already named correctly) is an error, but
-          # shouldn't count as a failure.
-          mv ${{ matrix.build_target.meta_json }} meta.json || true
           viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz

--- a/bin/package.ps1
+++ b/bin/package.ps1
@@ -5,17 +5,6 @@ $ErrorActionPreference = "Stop"
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 refreshenv
 
-# Fixup `meta.json` to have `.exe at the end
-Copy-Item meta.json meta.json.backup
-jq -f .\bin\fixup_windows_entrypoint.jq meta.json.backup | Out-File -FilePath meta.json -Encoding ASCII
-
 # Tar up all the command line arguments, then gzip them
 7z a -ttar module.tar $args
 7z a -tgzip -sdel module.tar.gz module.tar
-
-# Clean house. Keep the updated meta.json, which is needed for uploading the module from Github.
-if (Test-Path "meta.windows.json") {
-    Remove-Item "meta.windows.json"
-}
-Move-Item meta.json meta.windows.json
-Move-Item meta.json.backup meta.json

--- a/bin/setup.ps1
+++ b/bin/setup.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference = "Stop"
 
 # Set up conan and other friends we met along the way
-choco install -y conan cmake git 7zip jq
+choco install -y conan cmake git 7zip
 
 # Ensure that things installed with choco are visible to us
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1


### PR DESCRIPTION
Per today's discussion, Windows is smart enough to figure out that `build-conan/build/RelWithDebInfo/tflite_cpu` really means `build-conan/build/RelWithDebInfo/tflite_cpu.exe`, with a `.exe` on the end. So, let's get rid of all the effort we put into having different `meta.json`s on different platforms. This also prevents us running into bugs like the one Abe and I found today, when there is a mismatch between the global meta.json and the local one. (Maybe we'll still need to fix such bugs in the future, but at least it won't be for this module.)