### PR TITLE
have an rpi4-compatible build via the CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Build & publish module to registry
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 # This regex matches either a semver (e.g. 1.2.3)
 # or a release candidate in one of these forms:
@@ -14,19 +16,19 @@ on:
 # or [0-9]+.[0-9]+.[0-9]+-rc optionally followed by digits
 
 jobs:
-  validate-tag:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Validate tag format
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          echo "Validating tag: $TAG"
-          if [[ $TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]*)?$ ]]; then
-            echo "Tag matches semver."
-          else
-            echo "Error: tag does not match semver"
-            exit 1
-          fi
+  #  validate-tag:
+  #    runs-on: ubuntu-22.04
+  #    steps:
+  #      - name: Validate tag format
+  #        run: |
+  #          TAG="${{ github.event.release.tag_name }}"
+  #          echo "Validating tag: $TAG"
+  #          if [[ $TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]*)?$ ]]; then
+  #            echo "Tag matches semver."
+  #          else
+  #            echo "Error: tag does not match semver"
+  #            exit 1
+  #          fi
 
   # If we use the viamrobotics/build-action@v1, it farms out compilation to Linux machines no
   # matter which OS you're targeting (which is fine for Go and Python, but not for C++).
@@ -34,7 +36,7 @@ jobs:
   # instead, we're going to build everything on Github's action runners directly.
   build:
     name: Build the module
-    needs: validate-tag
+    #needs: validate-tag
     strategy:
       matrix:
         build_target:
@@ -74,7 +76,7 @@ jobs:
   # linux/arm64 build compatible with that.
   rpi4build:
     name: Build for Debian Bullseye (rpi4)
-    needs: validate-tag
+    #needs: validate-tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -127,5 +129,6 @@ jobs:
           path: .
       - name: Publish build to Viam registry
         run: |
-          viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz
+          ls -la
+          #viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
+          #viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
       # So, install python3, and then make a copy of it called just python. Don't care if we mess
       # up /bin: the entire container is going to be thrown out anyway.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt upgrade -y && apt install -y cmake curl git libstdc++6 make python3 python3-pip && cp $(which python3) /bin/python && conan install -r conancenter --update --tool-requires=b2/5.3.1 --build=b2 && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo/bin && ./build_bullseye.sh'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
             debian-bullseye-conan-
       # We do everything in a docker container running the same OS as rpi4.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt install -y cmake git make python3 python3-pip && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt install -y cmake curl git make python && curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" --output get-pip.py && python get-pip.py && make setup && make module.tar.gz'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
       # So, install python3, and then make a copy of it called just python. Don't care if we mess
       # up /bin: the entire container is going to be thrown out anyway.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt upgrade -y && apt install -y cmake curl git libstdc++6 make python3 python3-pip && cp $(which python3) /bin/python && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt upgrade -y && apt install -y cmake curl git libstdc++6 make python3 python3-pip && cp $(which python3) /bin/python && conan install -r conancenter --update --tool-requires=b2/5.3.1 --build=b2 && make setup && make module.tar.gz'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,9 +88,12 @@ jobs:
           key: debian-bullseye-conan-${{ hashFiles('**/conanfile.py') }}
           restore-keys: |
             debian-bullseye-conan-
-      # We do everything in a docker container running the same OS as rpi4.
+      # We do everything in a docker container running the same OS as rpi4. Debian Bullseye is old
+      # enough that the default python interpreter is Python2, but we're using Python3 features.
+      # So, install python3, and then make a copy of it called just python. Don't care if we mess
+      # up /bin: the entire container is going to be thrown out anyway.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt install -y cmake curl git make python && curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" --output get-pip.py && python get-pip.py && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt install -y cmake curl git make python3 python3-pip && cp $(which python3) /bin/python && make setup && make module.tar.gz'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
       # So, install python3, and then make a copy of it called just python. Don't care if we mess
       # up /bin: the entire container is going to be thrown out anyway.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt upgrade -y && apt install -y cmake curl git make python3 python3-pip && cp $(which python3) /bin/python && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt upgrade -y && apt install -y cmake curl git libstdc++6 make python3 python3-pip && cp $(which python3) /bin/python && make setup && make module.tar.gz'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,10 +88,7 @@ jobs:
           key: debian-bullseye-conan-${{ hashFiles('**/conanfile.py') }}
           restore-keys: |
             debian-bullseye-conan-
-      # We do everything in a docker container running the same OS as rpi4. Debian Bullseye is old
-      # enough that the default python interpreter is Python2, but we're using Python3 features.
-      # So, install python3, and then make a copy of it called just python. Don't care if we mess
-      # up /bin: the entire container is going to be thrown out anyway.
+      # We do everything in a docker container running the same OS as rpi4.
       - name: Setup and build
         run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo/bin && ./build_bullseye.sh'
       - name: Store the module as a temporary artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,6 @@ jobs:
         build_target:
           - runs_on: ubuntu-22.04
             cache_dir: ~/.conan2
-          - runs_on: ubuntu-22.04-arm
-            cache_dir: ~/.conan2
           - runs_on: macos-14
             cache_dir: ~/.conan2
           - runs_on: macos-13
@@ -72,12 +70,12 @@ jobs:
           name: ${{ matrix.build_target.runs_on }}-module-${{ github.sha }}
           path: module.tar.gz
 
-  # Raspberry Pi 4 runs Debian Bullseye, which uses an outdated version of glibc. Make a special
-  # build just for that.
+  # Raspberry Pi 4 runs Debian Bullseye, which uses an outdated version of glibc. Make the
+  # linux/arm64 build compatible with that.
   rpi4build:
     name: Build for Debian Bullseye (rpi4)
     needs: validate-tag
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -106,16 +104,13 @@ jobs:
           - platform: linux/amd64
             built_on: ubuntu-22.04
           - platform: linux/arm64
-            built_on: ubuntu-22.04-arm
+            built_on: debian-bullseye
           - platform: darwin/arm64
             built_on: macos-14
           - platform: darwin/amd64
             built_on: macos-13
           - platform: windows/amd64
             built_on: windows-2019
-          - platform: linux/arm64
-            built_on: debian-bullseye
-            registry_tags: codename:bullseye
     runs-on: ubuntu-latest
     steps:
       - name: Install Viam CLI
@@ -133,4 +128,4 @@ jobs:
       - name: Publish build to Viam registry
         run: |
           viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz --tags ${{ matrix.build_target.registry_tags }}
+          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,9 +72,34 @@ jobs:
           name: ${{ matrix.build_target.runs_on }}-module-${{ github.sha }}
           path: module.tar.gz
 
+  # Raspberry Pi 4 runs Debian Bullseye, which uses an outdated version of glibc. Make a special
+  # build just for that.
+  rpi4build:
+    name: Build for Debian Bullseye (rpi4)
+    needs: validate-tag
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Restore cached libraries
+        uses: actions/cache@v3
+        with:
+          path: ~/.conan2
+          key: debian-bullseye-conan-${{ hashFiles('**/conanfile.py') }}
+          restore-keys: |
+            debian-bullseye-conan-
+      # We do everything in a docker container running the same OS as rpi4.
+      - name: Setup and build
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 -it debian:bullseye bash -c 'cd /repo && apt update && apt install -y make && make setup && make module.tar.gz'
+      - name: Store the module as a temporary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-bullseye-module-${{ github.sha }}
+          path: module.tar.gz
+
   publish:
     name: Upload module
-    needs: build
+    needs: [build, rpi4build]
     strategy:
       matrix:
         build_target:
@@ -88,6 +113,9 @@ jobs:
             built_on: macos-13
           - platform: windows/amd64
             built_on: windows-2019
+          - platform: linux/arm64
+            built_on: debian-bullseye
+            registry_tags: codename:bullseye
     runs-on: ubuntu-latest
     steps:
       - name: Install Viam CLI
@@ -105,4 +133,4 @@ jobs:
       - name: Publish build to Viam registry
         run: |
           viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz
+          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz --tags ${{ matrix.build_target.registry_tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
       # So, install python3, and then make a copy of it called just python. Don't care if we mess
       # up /bin: the entire container is going to be thrown out anyway.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt install -y cmake curl git make python3 python3-pip && cp $(which python3) /bin/python && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt upgrade -y && apt install -y cmake curl git make python3 python3-pip && cp $(which python3) /bin/python && make setup && make module.tar.gz'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
             debian-bullseye-conan-
       # We do everything in a docker container running the same OS as rpi4.
       - name: Setup and build
-        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 -it debian:bullseye bash -c 'cd /repo && apt update && apt install -y make && make setup && make module.tar.gz'
+        run: docker run -v .:/repo -v ~/.conan2:/root/.conan2 debian:bullseye bash -c 'cd /repo && apt update && apt install -y cmake git make python3 python3-pip && make setup && make module.tar.gz'
       - name: Store the module as a temporary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/bin/build_bullseye.sh
+++ b/bin/build_bullseye.sh
@@ -19,8 +19,23 @@ apt upgrade -y
 # Debian Bullseye is old enough that the default python interpreter is Python2, but we're using
 # Python3 features. So, install python3, and then make a copy of it called just python. Don't care
 # if we mess up /bin: the entire container is going to be thrown out anyway.
-apt install -y cmake curl git libstdc++6 make python3 python3-pip
+apt install -y curl git libstdc++6 make python3 python3-pip
 cp $(which python3) /bin/python
+
+# Compiling the C++ SDK requires cmake version 3.25 or later, but Debian Bullseye only provides
+# cmake 3.18 or earlier. So, we need to build it from scratch.
+apt install -y wget build-essential checkinstall zlib1g-dev libssl-dev
+mkdir cmake
+pushd cmake
+# This is the version used in Ubuntu 24.04 as of May 2025.
+wget https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2.tar.gz
+tar xzvf cmake-3.30.2.tar.gz
+cd cmake-3.30.2
+./bootstrap
+make
+make install
+popd # cmake-3.30.2
+popd # cmake
 
 # Boost is installed via b2, but the pre-compiled versions of b2 require a more recent version of
 # glibcxx than is available on Debian Bullseye. So, instead, build it ourselves. and that means

--- a/bin/build_bullseye.sh
+++ b/bin/build_bullseye.sh
@@ -30,7 +30,7 @@ pushd cmake
 # This is the version used in Ubuntu 24.04 as of May 2025.
 wget https://github.com/Kitware/CMake/releases/download/v3.30.2/cmake-3.30.2.tar.gz
 tar xzvf cmake-3.30.2.tar.gz
-cd cmake-3.30.2
+pushd cmake-3.30.2
 ./bootstrap
 make
 make install
@@ -45,6 +45,8 @@ conan profile detect
 conan install -r conancenter --update --tool-requires=b2/5.3.1 --build=b2/5.3.1 -s compiler.cppstd=14 -s:a compiler.cppstd=14
 
 # Finally, build everything!
+pwd
+ls -la
 make setup
 make module.tar.gz
 

--- a/bin/build_bullseye.sh
+++ b/bin/build_bullseye.sh
@@ -26,6 +26,7 @@ cp $(which python3) /bin/python
 # glibcxx than is available on Debian Bullseye. So, instead, build it ourselves. and that means
 # installing conan before we get to the setup script.
 python -m pip install conan
+conan profile detect
 conan install -r conancenter --update --tool-requires=b2/5.3.1 --build=b2/5.3.1 -s compiler.cppstd=14 -s:a compiler.cppstd=14
 
 # Finally, build everything!

--- a/bin/build_bullseye.sh
+++ b/bin/build_bullseye.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# set -e: exit with errors if anything fails
+#     -u: it's an error to use an undefined variable
+#     -x: print out every command before it runs
+#     -o pipefail: if something in the middle of a pipeline fails, the whole thing fails
+set -euxo pipefail
+
+# Raspberry Pi 4 runs Debian Bullseye, which is old enough that it doesn't have a recent enough
+# glibc version for code compiled on the Github action runner's oldest version of Ubuntu. So,
+# instead, we compile everything in a Debian Bullseye docker container, to ensure it works on such
+# an old system. This bash script is what to run in the docker container.
+
+# We assume that the repository is mounted in /repo.
+pushd /repo
+
+apt update
+apt upgrade -y
+
+# Debian Bullseye is old enough that the default python interpreter is Python2, but we're using
+# Python3 features. So, install python3, and then make a copy of it called just python. Don't care
+# if we mess up /bin: the entire container is going to be thrown out anyway.
+apt install -y cmake curl git libstdc++6 make python3 python3-pip
+cp $(which python3) /bin/python
+
+# Boost is installed via b2, but the pre-compiled versions of b2 require a more recent version of
+# glibcxx than is available on Debian Bullseye. So, instead, build it ourselves. and that means
+# installing conan before we get to the setup script.
+python -m pip install conan
+conan install -r conancenter --update --tool-requires=b2/5.3.1 --build=b2/5.3.1 -s compiler.cppstd=14 -s:a compiler.cppstd=14
+
+# Finally, build everything!
+make setup
+make module.tar.gz
+
+popd # /repo

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -6,7 +6,7 @@
 set -euxo pipefail
 
 # Set up conan
-conan --version > /dev/null 2>&1 || python -m pip install conan
+conan --version > /dev/null 2>&1 || python3 -m pip install conan
 conan profile detect || echo "Conan is already installed"
 
 # Clone the C++ SDK repo

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -6,7 +6,7 @@
 set -euxo pipefail
 
 # Set up conan
-conan --version > /dev/null 2>&1 || python3 -m pip install conan
+conan --version > /dev/null 2>&1 || python -m pip install conan
 conan profile detect || echo "Conan is already installed"
 
 # Clone the C++ SDK repo


### PR DESCRIPTION
This splits out the linux/arm64 section to be its own special build inside a docker container running Debian Bullseye, which matches what the rpi4's run. The current linux/arm64 build doesn't work on rpi4 because it needs to recent a version of glibc.

The evidence that this works will be if the CI script can succeed. 