### PR TITLE
Pin the Go implementation for Debian Bullseye

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
   # compatible version, rather than the most specific (as of May 2025, but we're hoping to change
   # that).
   bullseye:
-    name: Pin the old Go code for Debian Bullseye
+    name: Upload the old Go code again for Debian Bullseye
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,9 +74,34 @@ jobs:
           name: ${{ matrix.build_target.runs_on }}-module-${{ github.sha }}
           path: module.tar.gz
 
+  # Some of our Raspberry Pi 4's are still running Debian Bullseye, which uses an outdated version
+  # of glibc, and our code needs a newer version. So, we need to pin the Bullseye users to the old
+  # code even though we're going to upload a new version for linux/arm64. This needs to be uploaded
+  # before the "normal" linux/arm64 build, because the Bullseye machines will take the first
+  # compatible version, rather than the most specific (as of May 2025, but we're hoping to change
+  # that).
+  bullseye:
+    name: Pin the old Go code for Debian Bullseye
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Viam CLI
+        run: |
+          sudo curl -o /usr/local/bin/viam https://storage.googleapis.com/packages.viam.com/apps/viam-cli/viam-cli-stable-linux-amd64
+          sudo chmod a+rx /usr/local/bin/viam
+      # Although we don't need to check out any of the code, we do need to check out meta.json.
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Re-copy the old code to the registry again for Bullseye
+        run: |
+          ls -la
+          #viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
+          #viam module download --version 0.1.3 --platform linux/arm64-codename-bullseye
+          #viam module upload --platform linux/arm64 --version ${{ github.ref_name }} --upload 0.1.3-linux-arm64-codename-bullseye/viam-tflite_cpu.tar.gz --tags codename:bullseye
+
   publish:
     name: Upload module
-    needs: build
+    needs: [build, bullseye]
     strategy:
       matrix:
         build_target:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Build & publish module to registry
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  release:
+    types: [published]
 
 # This regex matches either a semver (e.g. 1.2.3)
 # or a release candidate in one of these forms:
@@ -16,19 +14,19 @@ on:
 # or [0-9]+.[0-9]+.[0-9]+-rc optionally followed by digits
 
 jobs:
-  #  validate-tag:
-  #    runs-on: ubuntu-22.04
-  #    steps:
-  #      - name: Validate tag format
-  #        run: |
-  #          TAG="${{ github.event.release.tag_name }}"
-  #          echo "Validating tag: $TAG"
-  #          if [[ $TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]*)?$ ]]; then
-  #            echo "Tag matches semver."
-  #          else
-  #            echo "Error: tag does not match semver"
-  #            exit 1
-  #          fi
+  validate-tag:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Validate tag format
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          echo "Validating tag: $TAG"
+          if [[ $TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]*)?$ ]]; then
+            echo "Tag matches semver."
+          else
+            echo "Error: tag does not match semver"
+            exit 1
+          fi
 
   # If we use the viamrobotics/build-action@v1, it farms out compilation to Linux machines no
   # matter which OS you're targeting (which is fine for Go and Python, but not for C++).
@@ -36,7 +34,7 @@ jobs:
   # instead, we're going to build everything on Github's action runners directly.
   build:
     name: Build the module
-    #needs: validate-tag
+    needs: validate-tag
     strategy:
       matrix:
         build_target:
@@ -131,6 +129,5 @@ jobs:
           path: .
       - name: Publish build to Viam registry
         run: |
-          ls -la
-          #viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          #viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz
+          viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
+          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Build & publish module to registry
+
 on:
   release:
     types: [published]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Build & publish module to registry
 on:
-  release:
-    types: [published]
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 # This regex matches either a semver (e.g. 1.2.3)
 # or a release candidate in one of these forms:
@@ -14,19 +16,19 @@ on:
 # or [0-9]+.[0-9]+.[0-9]+-rc optionally followed by digits
 
 jobs:
-  validate-tag:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Validate tag format
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          echo "Validating tag: $TAG"
-          if [[ $TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]*)?$ ]]; then
-            echo "Tag matches semver."
-          else
-            echo "Error: tag does not match semver"
-            exit 1
-          fi
+  #  validate-tag:
+  #    runs-on: ubuntu-22.04
+  #    steps:
+  #      - name: Validate tag format
+  #        run: |
+  #          TAG="${{ github.event.release.tag_name }}"
+  #          echo "Validating tag: $TAG"
+  #          if [[ $TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]*)?$ ]]; then
+  #            echo "Tag matches semver."
+  #          else
+  #            echo "Error: tag does not match semver"
+  #            exit 1
+  #          fi
 
   # If we use the viamrobotics/build-action@v1, it farms out compilation to Linux machines no
   # matter which OS you're targeting (which is fine for Go and Python, but not for C++).
@@ -34,7 +36,7 @@ jobs:
   # instead, we're going to build everything on Github's action runners directly.
   build:
     name: Build the module
-    needs: validate-tag
+    #needs: validate-tag
     strategy:
       matrix:
         build_target:
@@ -104,5 +106,6 @@ jobs:
           path: .
       - name: Publish build to Viam registry
         run: |
-          viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz
+          ls -la
+          #viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
+          #viam module upload --platform ${{ matrix.build_target.platform }} --version ${{ github.ref_name }} --upload module.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
 name: Build & publish module to registry
-
 on:
   release:
     types: [published]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,10 +92,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Re-copy the old code to the registry again for Bullseye
         run: |
-          ls -la
-          #viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
-          #viam module download --version 0.1.3 --platform linux/arm64-codename-bullseye
-          #viam module upload --platform linux/arm64 --version ${{ github.ref_name }} --upload 0.1.3-linux-arm64-codename-bullseye/viam-tflite_cpu.tar.gz --tags codename:bullseye
+          viam login api-key --key-id ${{ secrets.viam_key_id }} --key ${{ secrets.viam_key_value }}
+          viam module download --version 0.1.3 --platform linux/arm64-codename-bullseye
+          viam module upload --platform linux/arm64 --version ${{ github.ref_name }} --upload 0.1.3-linux-arm64-codename-bullseye/viam-tflite_cpu.tar.gz --tags codename:bullseye
 
   publish:
     name: Upload module

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         run: make tflite_cpu
 
   # PRs should only be mergeable when all platforms can build the code. Instead of having 1
-  # requirement for each platform in the Github settings, have 1 rule that depends on every item
+  # requirement in the Github settings for each platform, have 1 rule that depends on every item
   # from the previous matrix, and have the Github check gate on this one.
   allow:
     name: "Lint and build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,8 @@ jobs:
   allow:
     name: "Lint and build"
     needs: build
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: All done
-        run: echo "all done"
+      - name: Check if all builds completed
+        run: [ "${{ needs.build.result }}" == "success" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check if all builds completed
-        run: [ "${{ needs.build.result }}" == "success" ]
+      - name: Check whether all builds completed
+        run: |
+          echo "Results of builds: ${{ needs.build.result }}"
+          [ "${{ needs.build.result }}" == "success" ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # TODO(RSDK-10636): run the build on windows-2019, too, when it's is tolerably fast
         runs_on: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, macos-13]
-    name: "Lint and build"
+    name: "Lint and build on each platform"
     runs-on: ${{ matrix.runs_on }}
 
     steps:
@@ -33,3 +33,14 @@ jobs:
 
       - name: Build
         run: make tflite_cpu
+
+  # PRs should only be mergeable when all platforms can build the code. Instead of having 1
+  # requirement for each platform in the Github settings, have 1 rule that depends on every item
+  # from the previous matrix, and have the Github check gate on this one.
+  allow:
+    name: "Lint and build"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: All done
+        run: echo "all done"


### PR DESCRIPTION
I gave up on https://github.com/viam-modules/mlmodel-tflite/pull/37, so this is a bandaid: every time we build a new version of the repo, copy the old Go code and reupload that as the "new" version for Debian Bullseye only.

~Assuming this version of the action succeeds, I'll revert https://github.com/viam-modules/mlmodel-tflite/commit/342664216cced15aa5012007b91faed7a68c2cbc, and add a reviewer.~ edit: done!

FWIW, the .tar.gz file with the old Go code does have a giant warning (both in the top-level directory and the directory that contains the entrypoint) explaining that this is not the C++ implementation.