### PR TITLE
Up to windows-2022 runner

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -16,7 +16,7 @@ jobs:
             cache_dir: ~/.conan2
           - runs_on: macos-13
             cache_dir: ~/.conan2
-          - runs_on: windows-2019
+          - runs_on: windows-2022
             cache_dir: C:\Users\runneradmin\.conan2
     runs-on: ${{ matrix.build_target.runs_on }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
             cache_dir: ~/.conan2
           - runs_on: macos-13
             cache_dir: ~/.conan2
-          - runs_on: windows-2019
+          - runs_on: windows-2022
             cache_dir: C:\Users\runneradmin\.conan2
     runs-on: ${{ matrix.build_target.runs_on }}
     steps:
@@ -111,7 +111,7 @@ jobs:
           - platform: darwin/amd64
             built_on: macos-13
           - platform: windows/amd64
-            built_on: windows-2019
+            built_on: windows-2022
     runs-on: ubuntu-latest
     steps:
       - name: Install Viam CLI


### PR DESCRIPTION
windows-2019 runner was retired
https://github.com/actions/runner-images/issues/12045

the action fails, so must be updated to windows-2022